### PR TITLE
Grammar in crew count record

### DIFF
--- a/GameData/RP-0/Contracts/Human Records/CrewedCountRecord.cfg
+++ b/GameData/RP-0/Contracts/Human Records/CrewedCountRecord.cfg
@@ -52,7 +52,7 @@ CONTRACT_TYPE
 	{
 		name = crewCountInSpace
 		type = All
-		title = Have @/crewedTargetCount on the same vessel while in space in a stable orbit.
+		title = Have @/crewedTargetCount crew on the same vessel while in space in a stable orbit.
 		
 		disableOnStateChange = False
 		


### PR DESCRIPTION
Missing "crew" added to the description of crew count records.